### PR TITLE
getBenchmarkData returns a data frame when dryrun=TRUE (default)

### DIFF
--- a/R/MicrobiomeBenchmarkData.R
+++ b/R/MicrobiomeBenchmarkData.R
@@ -12,7 +12,8 @@
 #' names of the datasets as a character vector. If FALSE, it returns the
 #' TreeSummarizedExperiment datasets indicated in the argument 'x'.
 #'
-#' @return A list of TreeSummarizedExperiments.
+#' @return A list of TreeSummarizedExperiments when dryrun = FALSE. A data
+#' frame with the datasets characteristics when dryrun = TRUE.
 #'
 #' @export
 #'
@@ -38,7 +39,12 @@ getBenchmarkData <- function(x, dryrun = TRUE) {
                 "\n\nUse getBenchmarkData(dryrun = FALSE)",
                 " to import all of the datasets."
             )
-            return(invisible(titles))
+
+            fname <- system.file(
+                'extdata/datasets.tsv', package = 'MicrobiomeBenchmarkData'
+            )
+            return(read.table(fname, header = TRUE, sep = '\t'))
+            # return(invisible(titles))
         } else if (isFALSE(dryrun)) {
             x <- titles
         }

--- a/man/getBenchmarkData.Rd
+++ b/man/getBenchmarkData.Rd
@@ -17,7 +17,8 @@ names of the datasets as a character vector. If FALSE, it returns the
 TreeSummarizedExperiment datasets indicated in the argument 'x'.}
 }
 \value{
-A list of TreeSummarizedExperiments.
+A list of TreeSummarizedExperiments when dryrun = FALSE. A data
+frame with the datasets characteristics when dryrun = TRUE.
 }
 \description{
 \code{getBenchmarkData} imports datasets as TreeSummarizedExperiment objects.


### PR DESCRIPTION
+ Now `getBenchmarkData` returns a data frame with the summary of the datasets when `dryrun=TRUE` (which is the default value). This is based on recommendation son #2 